### PR TITLE
Update dependencies

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -2,10 +2,9 @@ packages: .
 
 source-repository-package
     type: git
-    -- location: https://github.com/haskell-nix/hnix-store.git
-    location: https://github.com/obsidiansystems/hnix-store.git
-    branch: derivation-work
-    tag: 7a4aef8c8e548cc9cc7908b39491f36ee75bc89f
+    location: https://github.com/haskell-nix/hnix-store.git
+    branch: master
+    tag: fb9ac20c18575b5d39f0464251017416eccd5f29
     subdir: hnix-store-core
     subdir: hnix-store-json
     -- subdir: hnix-store-remote

--- a/default.nix
+++ b/default.nix
@@ -14,26 +14,6 @@ rec {
     {
       overlays = [
         (import ./dep/nix).overlays.default
-        # Until bump to 25.05
-        (self: super: {
-          nixDependencies2 = super.nixDependencies2.overrideScope (super': self': {
-            boost = (super.boost.override {
-                extraB2Args = [
-                  "--with-container"
-                  "--with-context"
-                  "--with-coroutine"
-                  "--with-iostreams"
-                  "--with-regex"
-                ];
-                enableIcu = false;
-              }).overrideAttrs
-                (old: {
-                  # Need to remove `--with-*` to use `--with-libraries=...`
-                  buildPhase = lib.replaceStrings [ "--without-python" ] [ "" ] old.buildPhase;
-                  installPhase = lib.replaceStrings [ "--without-python" ] [ "" ] old.installPhase;
-                });
-          });
-        })
       ];
     }
     // nixpkgsArgs

--- a/dep/hnix-store/github.json
+++ b/dep/hnix-store/github.json
@@ -3,6 +3,7 @@
   "repo": "hnix-store",
   "branch": "derivation-work",
   "private": false,
-  "rev": "7a4aef8c8e548cc9cc7908b39491f36ee75bc89f",
-  "sha256": "1zjvcmf8f8hzc2d8l5d59izdc1gx8l9ijab01ikmi3y2sg8ldlqv"
+  "fetchSubmodules": true,
+  "rev": "12114d9d5bde9ed489335027d376982b3eb17e4b",
+  "sha256": "1kyz6iriql0ba73g66wjyr2am0x3i0dqnrls8im1a88vfvhsyzym"
 }

--- a/dep/nix/github.json
+++ b/dep/nix/github.json
@@ -2,6 +2,6 @@
   "owner": "nixos",
   "repo": "nix",
   "private": false,
-  "rev": "b4bea57667eb5413dbc808dd11c10106ef91c770",
-  "sha256": "1s1f4pxmkb7p53kfvmy2j0d9505vi2aqbm2fknzjk608hsqkq83w"
+  "rev": "2c6d06e9387cf58167cb5a7ab91cee7333d8d17c",
+  "sha256": "0nmyqsysv9k9rpf6nyi8dkylf9dcmii0yc952js6wxhmdwsllgms"
 }

--- a/dep/nixpkgs/github.json
+++ b/dep/nixpkgs/github.json
@@ -1,8 +1,8 @@
 {
   "owner": "nixos",
   "repo": "nixpkgs",
-  "branch": "release-24.11",
+  "branch": "release-26.05",
   "private": false,
-  "rev": "8840c8cd60b8049626755bc88531c8bf6f0c60dc",
-  "sha256": "1gw09mzbmsbygrdjl1sz2wrg5i8jja783nhrbv3i184i784xyzqk"
+  "rev": "6b316287bae2ee04c9b93c8c858d930fd07d7338",
+  "sha256": "0mpcj1cn2hl2z7w87z6qimwx14i4gb2c60mybj7p9c2ksmmi2wvd"
 }

--- a/sandstone.cabal
+++ b/sandstone.cabal
@@ -77,7 +77,7 @@ library
 
   build-depends:
     aeson,
-    base ^>=4.18.2.1,
+    base,
     bytestring,
     containers,
     data-default,


### PR DESCRIPTION
nixpkgs, nix, and hnix-store all seemed to be linked.

This is still using a fork of hnix-store due an issue in json formats. It should be fixed in haskell-nix/hnix-store#316